### PR TITLE
switch to dynamic envs

### DIFF
--- a/src/api/RemoteAPI.ts
+++ b/src/api/RemoteAPI.ts
@@ -1,5 +1,8 @@
+// TODO switch to private var, when RemoteAPI is called only server side import { env } from '$env/dynamic/private';
+import { env } from '$env/dynamic/public';
+
 const apiRequest = async (method: RequestInit['method'], path: string, payload?: unknown) => {
-	const baseUrl = import.meta.env.VITE_BASE_URL?.replace(/\/+$/, '') || '';
+	const baseUrl = env.PUBLIC_BASE_URL?.replace(/\/+$/, '') || '';
 	const url = `${baseUrl}${path}`;
 	const response = await fetch(url, {
 		method,

--- a/src/components/items/ItemLink.svelte
+++ b/src/components/items/ItemLink.svelte
@@ -5,7 +5,7 @@
 	export let type;
 </script>
 
-<a class={`link link-${type}`} href={`${import.meta.env.VITE_ADMIN_PAGE_BASE_URL}/items/${item._id}`}
+<a class={`link link-${type}`} href={`/items/${item._id}`}
 	>{item.name}</a
 >
 

--- a/src/components/items/itemDetail.svelte
+++ b/src/components/items/itemDetail.svelte
@@ -38,7 +38,8 @@
 		if (item._id) {
 			selectablePeople = await getAllSelectablePeople(item._id);
 			await fetchAllItemEvents();
-		isLoading = false;} else {
+			isLoading = false;
+		} else {
 			nonExistingItem = true;
 		}
 	});
@@ -156,7 +157,7 @@
 {:else}
 	<Error>
 		Oh no. Looks like this item doesnt exits.
-		<a class={`link`} href={`${import.meta.env.VITE_ADMIN_PAGE_BASE_URL}`}>Go home.</a>
+		<a class={`link`} href="/">Go home.</a>
 	</Error>
 {/if}
 

--- a/src/components/people/PersonLink.svelte
+++ b/src/components/people/PersonLink.svelte
@@ -7,7 +7,7 @@
 
 <a
 	class={`link link-${type}`}
-	href={`${import.meta.env.VITE_ADMIN_PAGE_BASE_URL}/people/${person._id}`}>{person.name}</a
+	href={`/people/${person._id}`}>{person.name}</a
 >
 
 <style>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
-/** @type {import('@sveltejs/kit').Handle} */
+import { env } from '$env/dynamic/private';
 
+/** @type {import('@sveltejs/kit').Handle} */
 export async function handle({
 	event,
 	resolve
@@ -8,7 +9,7 @@ export async function handle({
 
 	if (url.pathname.startsWith('/')) {
 		const auth = event.request.headers.get('Authorization');
-		if (auth !== `Basic ${btoa(import.meta.env.VITE_ADMIN_LOGIN)}`) {
+		if (auth !== `Basic ${btoa(env.ADMIN_LOGIN)}`) {
 			return new Response('Not authorized', {
 				status: 401,
 				headers: {

--- a/src/routes/people/[id]/+page.svelte
+++ b/src/routes/people/[id]/+page.svelte
@@ -40,8 +40,7 @@
 {:else if invalidPerson}
 	<Error
 		>Uh no. This person doesnt exist.
-		<a class="link" href={`${import.meta.env.VITE_ADMIN_PAGE_BASE_URL}/people`}>Check all people here.</a
-		>
+		<a class="link" href="/people">Check all people here.</a>
 	</Error>
 {:else}
 	<PersonDetail person={data} {futureEvents} {runningEvents} />


### PR DESCRIPTION
converted all built-time static envs to dynamics.
We can make the backend-baseurl also server only, as soon as we route all api calls through sveltekit. for now it has to be public because client code is still using the RemoteAPI